### PR TITLE
Add ci to run pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make
+          python -m pip install pytest pytest_mock
+      - name: Test with pytest
+        run: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
 
     container:
-      image: python:${{ matrix.python_version }}-alpine
+      image: python:${{ matrix.python-version }}-alpine
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python setup.py install
-          python -m pip install openai[embeddings]
-          python -m pip install openai[wandb]
-          python -m pip install openai[datalib]
-          python -m pip install pytest pytest_mock
+          python -m pip install -e .[all]
       - name: Test with pytest
         run: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,4 +26,4 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[all]
       - name: Test with pytest
-        run: pytest
+        run: python -m pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[all]
+          python -m pip install -e .[dev,datalib,wandb,embeddings]
       - name: Test with pytest
         run: python -m pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Test with pytest
         run: python -m pytest
         env:
-          OPENAI_API_KEY: {{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          make
+          python setup.py install
+          python -m pip install openai[embeddings]
+          python -m pip install openai[wandb]
+          python -m pip install openai[datalib]
           python -m pip install pytest pytest_mock
       - name: Test with pytest
         run: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,5 @@ jobs:
           python -m pip install -e .[dev,datalib,wandb,embeddings]
       - name: Test with pytest
         run: python -m pytest
+        env:
+          OPENAI_API_KEY: {{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
 
     container:
-      image: python:${{ matrix.python_version }}
+      image: python:${{ matrix.python_version }}-alpine
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,15 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
+
+    container:
+      image: python:${{ matrix.python_version }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
 
+    # This job sets up Python versions using Python images instead of
+    # actions/setup-python because Python 3.7.1 does not exist in
+    # the GitHub local cache. Once the support for Python 3.7.1 is
+    # dropped, this job can be simplified to use actions/setup-python.
     container:
       image: python:${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.7.1", "3.8", "3.9", "3.10", "3.11"]
 
     container:
-      image: python:${{ matrix.python-version }}-alpine
+      image: python:${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /public/dist
 __pycache__
 build
+dist
 *.egg
 .vscode/settings.json
 .ipynb_checkpoints

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -423,7 +423,7 @@ def completions_space_start_validator(df):
 
     def add_space_start(x):
         x["completion"] = x["completion"].apply(
-            lambda x: ("" if x[0] == " " else " ") + x
+            lambda x: ("" if x == "" or x[0] == " " else " ") + x
         )
         return x
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,11 +51,6 @@ embeddings =
   pandas >= 1.2.3  # Needed for CLI fine-tuning data preparation tool
   pandas-stubs >= 1.1.0.11  # Needed for type hints for mypy
   openpyxl >= 3.0.7  # Needed for CLI fine-tuning data preparation tool xlsx format
-all =
-  dev
-  datalib
-  wandb
-  embeddings
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,11 @@ embeddings =
   pandas >= 1.2.3  # Needed for CLI fine-tuning data preparation tool
   pandas-stubs >= 1.1.0.11  # Needed for type hints for mypy
   openpyxl >= 3.0.7  # Needed for CLI fine-tuning data preparation tool xlsx format
+all =
+  dev
+  datalib
+  wandb
+  embeddings
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
- Add CI to run unit tests.
- An action secret, `OPENAI_API_KEY`, should be added to the repo that enables this job.
